### PR TITLE
Save/restore mode: hide saving/restoring of NSR register from user

### DIFF
--- a/examples/b_SavingKnowledge/b_SavingKnowledge.ino
+++ b/examples/b_SavingKnowledge/b_SavingKnowledge.ino
@@ -136,7 +136,6 @@ void saveNetworkKnowledge ( void )
   const char *filename = "NeurData.dat";
   SerialFlashFile file;
 
-  uint16_t savedState = CuriePME.beginSaveMode();
   Intel_PMT::neuronData neuronData;
   uint32_t fileSize = 128 * sizeof(neuronData);
 
@@ -149,6 +148,7 @@ void saveNetworkKnowledge ( void )
   file = SerialFlash.open(filename);
   file.erase();
 
+  CuriePME.beginSaveMode();
   if (file) {
     // iterate over the network and save the data.
     while( uint16_t nCount = CuriePME.iterateNeuronsToSave(neuronData)) {
@@ -170,7 +170,7 @@ void saveNetworkKnowledge ( void )
     }
   }
 
-  CuriePME.endSaveMode(savedState);
+  CuriePME.endSaveMode();
   Serial.print("Knowledge Set Saved. \n");
 }
 

--- a/examples/c_RestoringKnowledge/c_RestoringKnowledge.ino
+++ b/examples/c_RestoringKnowledge/c_RestoringKnowledge.ino
@@ -100,12 +100,12 @@ void restoreNetworkKnowledge ( void )
   SerialFlashFile file;
   int32_t fileNeuronCount = 0;
 
-  uint16_t savedState = CuriePME.beginRestoreMode();
   Intel_PMT::neuronData neuronData;
 
 	// Open the file and write test data
   file = SerialFlash.open(filename);
 
+  CuriePME.beginRestoreMode();
   if (file) {
     // iterate over the network and save the data.
     while(1) {
@@ -150,7 +150,7 @@ void restoreNetworkKnowledge ( void )
     }
   }
 
-  CuriePME.endRestoreMode(savedState);
+  CuriePME.endRestoreMode();
   Serial.print("Knowledge Set Restored. \n");
 }
 

--- a/src/CuriePME.h
+++ b/src/CuriePME.h
@@ -85,19 +85,13 @@ public:
 	uint16_t readNeuron( int32_t neuronID, neuronData& data_array);
 
 	// save and restore knowledge
-	uint16_t beginSaveMode( void );  // passes back the contents of the NSR register
+	void beginSaveMode(void);  // saves the contents of the NSR register
 	uint16_t iterateNeuronsToSave( neuronData& data_array );
-	uint16_t endSaveMode(void);
-	// you can optionally restore the NSR register by passing the value from
-	// from beginSaveMode()
-	uint16_t endSaveMode(uint16_t);
+	void endSaveMode(void); // restores the NSR value saved by beginSaveMode
 
-	uint16_t beginRestoreMode( void );// passes back the contents of the NSR register
+	void beginRestoreMode(void);
 	uint16_t iterateNeuronsToRestore( neuronData& data_array );
-	uint16_t endRestoreMode(void);
-	// you can optionally restore the NSR register by passing the value from
-	// from beginRestoreMode() you may not want this when restoring a network.
-	uint16_t endRestoreMode(uint16_t);
+	void endRestoreMode(void);
 
 	//getter and setters
 	PATTERN_MATCHING_DISTANCE_MODE getDistanceMode(void);
@@ -197,6 +191,10 @@ public:
 	{
 		*regAddress(reg) = value;
 	}
+
+private:
+    uint16_t nsr_save;
+
 };
 
 extern Intel_PMT CuriePME;


### PR DESCRIPTION
Instead of requiring the user to handle the contents of the NSR register during save/restore mode,
just hide it behind the scenes in a private variable.

@bigdinotech @SidLeung @intel-larry please review