### PR TITLE
Fix two errors in example Makefiles for CODK

### DIFF
--- a/examples/b_SavingKnowledge/Makefile
+++ b/examples/b_SavingKnowledge/Makefile
@@ -9,8 +9,8 @@ current_dir = $(shell pwd)
 VERBOSE  = true
 
 LIBDIRS  = $(ARDUINOSW_DIR)/corelibs/libraries/Intel-Pattern-Matching-Technology/src \
-		   $(ARDUINOSW_DIR)/corelibs/libraries/SPI/src \ 
-		   $(ARDUINOSW_DIR)/corelibs/libraries/SerialFlash/src 
+		   $(ARDUINOSW_DIR)/corelibs/libraries/SPI/src \
+		   $(ARDUINOSW_DIR)/corelibs/libraries/SerialFlash
 
 include $(ARDUINOSW_DIR)/Makefile.inc
 

--- a/examples/c_RestoringKnowledge/Makefile
+++ b/examples/c_RestoringKnowledge/Makefile
@@ -9,8 +9,8 @@ current_dir = $(shell pwd)
 VERBOSE  = true
 
 LIBDIRS  = $(ARDUINOSW_DIR)/corelibs/libraries/Intel-Pattern-Matching-Technology/src \
-		   $(ARDUINOSW_DIR)/corelibs/libraries/SPI/src \ 
-		   $(ARDUINOSW_DIR)/corelibs/libraries/SerialFlash/src 
+		   $(ARDUINOSW_DIR)/corelibs/libraries/SPI/src \
+		   $(ARDUINOSW_DIR)/corelibs/libraries/SerialFlash
 
 include $(ARDUINOSW_DIR)/Makefile.inc
 

--- a/examples/d_k-nearest-neighbor/Makefile
+++ b/examples/d_k-nearest-neighbor/Makefile
@@ -9,8 +9,8 @@ current_dir = $(shell pwd)
 VERBOSE  = true
 
 LIBDIRS  = $(ARDUINOSW_DIR)/corelibs/libraries/Intel-Pattern-Matching-Technology/src \
-		   $(ARDUINOSW_DIR)/corelibs/libraries/SPI/src \ 
-		   $(ARDUINOSW_DIR)/corelibs/libraries/SerialFlash/src 
+		   $(ARDUINOSW_DIR)/corelibs/libraries/SPI/src \
+		   $(ARDUINOSW_DIR)/corelibs/libraries/SerialFlash
 
 include $(ARDUINOSW_DIR)/Makefile.inc
 


### PR DESCRIPTION
1. LIBDIRS variable is broken over multiple lines, but there was some trailing
   whitespace after an escape "\" character, meaning the escape only affected
   the space rather than the following newline character

2. Wrong include path for SerialFlash library

@calvinatintel please review