### PR TITLE
Create class constant CuriePME.noMatch

### DIFF
--- a/examples/DrawingInTheAir/DrawingInTheAir.ino
+++ b/examples/DrawingInTheAir/DrawingInTheAir.ino
@@ -40,10 +40,6 @@ const unsigned int sampleRateHZ = 200;
 /* No. of bytes that one neuron can hold */
 const unsigned int vectorNumBytes = 128;
 
-/* Magic number returned by the PME if input data can't
- * be classified */
-const unsigned int noMatch = 0x7fff;
-
 /* Number of processed samples (1 sample == accel x, y, z)
  * that can fit inside a neuron */
 const unsigned int samplesPerVector = (vectorNumBytes / 3);
@@ -91,7 +87,7 @@ void loop ()
      * from 1-26, representing a letter from A-Z */
     category = CuriePME.classify(vector, vectorNumBytes);
 
-    if (category == noMatch) {
+    if (category == CuriePME.noMatch) {
         Serial.println("Don't recognise that one-- try again.");
     } else {
         letter = category + upperStart;

--- a/examples/a_SimplePatternMatching/a_SimplePatternMatching.ino
+++ b/examples/a_SimplePatternMatching/a_SimplePatternMatching.ino
@@ -50,7 +50,7 @@ void loop() {
     Serial.print("You entered: ");
     printVector(vector);
 
-    if( answer == 0x7FFF ) {
+    if( answer == CuriePME.noMatch ) {
       Serial.print("Which didn't match any of the trained categories.\n");
     } else {
       Serial.print("The closest match to the trained data \n");

--- a/examples/b_SavingKnowledge/b_SavingKnowledge.ino
+++ b/examples/b_SavingKnowledge/b_SavingKnowledge.ino
@@ -66,7 +66,7 @@ void loop() {
     Serial.print("You entered: ");
     printVector(vector);
 
-    if( answer == 0x7FFF ) {
+    if( answer == CuriePME.noMatch ) {
       Serial.print("Which didn't match any of the trained categories.\n");
     } else {
       Serial.print("The closest match to the trained data \n");

--- a/examples/c_RestoringKnowledge/c_RestoringKnowledge.ino
+++ b/examples/c_RestoringKnowledge/c_RestoringKnowledge.ino
@@ -64,7 +64,7 @@ void loop() {
     Serial.print("You entered: ");
     printVector(vector);
 
-    if( answer == 0x7FFF ) {
+    if( answer == CuriePME.noMatch ) {
       Serial.print("Which didn't match any of the trained categories.\n");
     } else {
       Serial.print("The closest match to the trained data \n");

--- a/src/CuriePME.h
+++ b/src/CuriePME.h
@@ -31,6 +31,7 @@ class Intel_PMT
 
 public:
 
+	static const uint32_t noMatch = 0x7fff;
 	static const int32_t MaxVectorSize = 128;
 	static const int32_t FirstNeuronID = 1;
 	static const int32_t LastNeuronID = 128;


### PR DESCRIPTION
The alternative is to tell the user they need a #define for the magic
number 0x7fff