### PR TITLE
d_k-nearest-neighbor.ino: fix calls to old RestoreMode methods

### DIFF
--- a/examples/d_k-nearest-neighbor/d_k-nearest-neighbor.ino
+++ b/examples/d_k-nearest-neighbor/d_k-nearest-neighbor.ino
@@ -146,7 +146,7 @@ void restoreNetworkKnowledge ( void )
   SerialFlashFile file;
   int32_t fileNeuronCount = 0;
 
-  uint16_t savedState = CuriePME.beginRestoreMode();
+  CuriePME.beginRestoreMode();
   Intel_PMT::neuronData neuronData;
 
   // Open the file and read test data
@@ -193,7 +193,7 @@ void restoreNetworkKnowledge ( void )
     }
   }
 
-  CuriePME.endRestoreMode(savedState);
+  CuriePME.endRestoreMode();
   Serial.print("Knowledge Set Restored. \n");
 }
 


### PR DESCRIPTION
The new methods do not return anything, or take any parameters