### PR TITLE
CuriePME.cpp: make classify() sort matching categories by distance

### DIFF
--- a/src/CuriePME.cpp
+++ b/src/CuriePME.cpp
@@ -116,8 +116,12 @@ uint16_t Intel_PMT::classify(uint8_t *pattern_vector, int32_t vector_length)
 	}
 	regWrite16( LCOMP , current_vector[vector_length - 1] );
 
-	return  ( regRead16(CAT) & CAT_CATEGORY);
+	// Sort matching categories by (We don't care about the returned value here;
+	// reading the distance register sorts matched categories by distance)
+	regRead16(IDX_DIST);
 
+	// Return the category with the lowest distance to point
+	return  (regRead16(CAT) & CAT_CATEGORY);
 }
 
 // write vector is used for kNN recognition and does not alter


### PR DESCRIPTION
The classify() function is returning the lowest matching category value,
without regard to distance. Reading the distance register before reading the
category causes the categories to be sorted by distance, and we can
return the category with the lowest distance, which is probably the
expected behaviour of this function.

To test, apply the changes from this PR, and run the simplePatternMatching example.

In the Serial terminal, enter **3, 57, 33**. This should be classified as category 3.
(Before this commit, it would be incorrectly classified as category 1).