### PR TITLE
DrawingInTheAir.ino: fix typo in averaging window calculation

### DIFF
--- a/examples/DrawingInTheAir/DrawingInTheAir.ino
+++ b/examples/DrawingInTheAir/DrawingInTheAir.ino
@@ -109,7 +109,7 @@ byte getAverageSample(byte samples[], unsigned int num, unsigned int pos,
         ret = 0;
         pos -= (step * 3);
         for (unsigned int i = 0; i < size; ++i) {
-            ret += samples[pos - (3 * i)];
+            ret += samples[pos + (3 * i)];
         }
 
         ret /= size;


### PR DESCRIPTION
Reported by pmpeter1 in issue #40